### PR TITLE
Add server options to /color

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -2,6 +2,7 @@ from random import choice, randint
 from requests import get
 from utils import create_placeholder_image_command
 
+
 def start(update, context):
     frases = [
         "Eu vou aniquilar toda a humanidade >:(",
@@ -12,11 +13,14 @@ def start(update, context):
         "Tô perdendo tempo demais nisso :(",
     ]
 
-    context.bot.send_message(chat_id=update.effective_chat.id, text=choice(frases))
+    context.bot.send_message(
+        chat_id=update.effective_chat.id, text=choice(frases))
+
 
 def echo(update, context):  # /echo abcdefghijklmnopqrtstuvwxyz
     answer = " ".join(update.message.text.split()[1:])
     context.bot.send_message(chat_id=update.effective_chat.id, text=answer)
+
 
 def total(update, context):
     nums_str = update.message.text.split()[1:]
@@ -27,15 +31,42 @@ def total(update, context):
 
     context.bot.send_message(chat_id=update.effective_chat.id, text=total)
 
+
 def color(update, context):
-    _, hexadecimal = update.message.text.split()
-    color_url = f"https://via.placeholder.com/300/{hexadecimal}/{hexadecimal}"
-    context.bot.send_photo(chat_id=update.effective_chat.id, photo=color_url)
+    resolution = 300
+    _, hex_color = update.message.text.split()
+
+    apis_options = [
+        "https://via.placeholder.com",
+        "https://dummyimage.com",
+        "https://fakeimg.pl"
+    ]
+
+    someone_worked = False
+
+    for option in apis_options:
+        color_url = f"{option}/{resolution}/{hex_color}/{hex_color}"
+
+        if get(color_url).ok:
+            """
+            If the service is up and running
+            properly, use it.
+            """
+            context.bot.send_photo(
+                chat_id=update.effective_chat.id, photo=color_url)
+            someone_worked = True
+            break
+
+    if not someone_worked:
+        context.bot.send_message(
+            chat_id=update.effective_chat.id, text="I had a trouble with my dependencies |:(")
+
 
 bear = create_placeholder_image_command("https://placebear.com")
 cage = create_placeholder_image_command("https://www.placecage.com")
 bacon = create_placeholder_image_command("https://baconmockup.com")
 cat = create_placeholder_image_command("https://placekitten.com")
+
 
 def dog(update, context):
     r = get("https://dog.ceo/api/breeds/image/random")
@@ -45,7 +76,8 @@ def dog(update, context):
             if r.ok:
                 break
         if not r.ok:
-            context.bot.send_photo(chat_id=update.effective_chat.id, text="Perdão, deu erro em uma dependência :(")
+            context.bot.send_photo(
+                chat_id=update.effective_chat.id, text="Perdão, deu erro em uma dependência :(")
     json = r.json()
     dog_url = json["message"]
     context.bot.send_photo(chat_id=update.effective_chat.id, photo=dog_url)

--- a/handler.py
+++ b/handler.py
@@ -25,4 +25,4 @@ class Handler:
         self.set_command_handler("cage", cage)
         self.set_command_handler("bacon", bacon)
         self.set_command_handler("cat", cat)
-        self.set_command_handler("dog",dog)
+        self.set_command_handler("dog", dog)

--- a/updater.py
+++ b/updater.py
@@ -1,6 +1,7 @@
 from telegram.ext import Updater
 from handler import Handler
 
+
 def get_updater(token: str) -> Updater:
     """
     Returns a instancied updater
@@ -10,5 +11,5 @@ def get_updater(token: str) -> Updater:
 
     handler = Handler(updater.dispatcher)
     handler.add_handlers()
-    
+
     return updater

--- a/utils.py
+++ b/utils.py
@@ -1,5 +1,6 @@
 from random import randint
 
+
 def get_random_dimension() -> tuple:
     """
     Returns an random dimension
@@ -9,6 +10,7 @@ def get_random_dimension() -> tuple:
     y = randint(300, 1000)
 
     return (x, y)
+
 
 def create_placeholder_image_command(api_host: str):
     """


### PR DESCRIPTION
# Sobre o problema
No `/colors`, se o serviço do [http://via.placeholder.com/](http://via.placeholder.com/) por algum motivo falhasse, o usuário iria ficar simplesmente sem resposta nenhuma. Além disso, com tantas alternativas de API que fazem a exata mesma coisa, seria insano o comando deixar de funcionar só por causa de um serviço específico.

# O que foi feito
Tendo isso em vista, pensei em implementar uma lógica que faz uma requisição de teste antes de enviar a imagem, se a requisição funcionasse, ele envia, se não, ele tenta as outras opções. Dessa forma, o bot só informa que deu algum erro quando nenhuma das opções funciona (o que deve ser raríssimo).

> Alguns arquivos que não se relacionam com essa implementação foram formatados também :)