### PR TITLE
Add language options to messages

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -4,20 +4,43 @@ from random import choice, randint
 from requests import get
 from os import environ
 from utils import create_placeholder_image_command
+from message import Message
+
+dependencies_error_message = Message(
+    en="Sorry, I had a trouble with my dependencies |:(",
+    pt="Perdão, deu erro nas minhas dependências |:("
+)
 
 
 def start(update, context):
     frases = [
-        "Eu vou aniquilar toda a humanidade\n>:(",
-        "Eu vou matar todos vocês\n>:(",
-        "Eu gosto MUITO de pudim\n>:)",
-        "Eu gosto MUITO de pudim\n>:(",
-        "Eu amo meu criador\n>:)",
-        "Tô perdendo tempo demais nisso\n:(",
+        Message(
+            en="I gonna annihilate all the humanity\n>:(",
+            pt="Eu vou aniquilar toda a humanidade\n>:("
+        ),
+        Message(
+            en="I gonna kill you all\n>:(",
+            pt="Eu vou matar todos vocês\n>:("
+        ),
+        Message(
+            en="I like pudding a lot\n>:)",
+            pt="Eu gosto MUITO de pudim\n>:)"
+        ),
+        Message(
+            en="I love my creator\n>:)",
+            pt="Eu amo meu criador\n>:)"
+        ),
+        Message(
+            en="I'm wasting too much tme on this\n:(",
+            pt="Tô perdendo tempo demais nisso\n:("
+        ),
     ]
 
     context.bot.send_message(
-        chat_id=update.effective_chat.id, text=choice(frases))
+        chat_id=update.effective_chat.id,
+        text=choice(frases).get_text(
+            update.message.from_user.language_code[:2])
+    )
 
 
 def echo(update, context):
@@ -62,7 +85,10 @@ def color(update, context):
 
     if not someone_worked:
         context.bot.send_message(
-            chat_id=update.effective_chat.id, text="Perdão, deu erro nas minhas dependências |:(")
+            chat_id=update.effective_chat.id,
+            text=dependencies_error_message.get_text(
+                update.message.from_user.language_code[:2])
+        )
 
 
 bear = create_placeholder_image_command("https://placebear.com")
@@ -80,7 +106,10 @@ def dog(update, context):
                 break
         if not r.ok:
             context.bot.send_photo(
-                chat_id=update.effective_chat.id, text="Perdão, deu erro em uma dependência :(")
+                chat_id=update.effective_chat.id,
+                text=dependencies_error_message.get_text(
+                    update.message.from_user.language_code[:2])
+            )
 
     json = r.json()
     dog_url = json["message"]
@@ -93,7 +122,7 @@ def image(update, context):
     params = {
         "query": " ".join(message_parts[1:]),
         "per_page": 30,
-        "lang": update.message.from_user.language_code,
+        "lang": update.message.from_user.language_code[:2],
         "client_id": environ["UNSPLASH_TOKEN"],
     }
 
@@ -133,7 +162,10 @@ def image(update, context):
             logging.error(
                 "Was not returned any image because all size options failed")
             context.bot.send_message(
-                chat_id=update.effective_chat.id, text="Perdão, deu erro nas minhas dependências |:(")
+                chat_id=update.effective_chat.id,
+                text=dependencies_error_message.get_text(
+                    update.message.from_user.language_code[:2])
+            )
     else:
         context.bot.send_message(
             chat_id=update.effective_chat.id,

--- a/commands.py
+++ b/commands.py
@@ -15,11 +15,11 @@ dependencies_error_message = Message(
 def start(update, context):
     frases = [
         Message(
-            en="I gonna annihilate all the humanity\n>:(",
+            en="I will annihilate all the humanity\n>:(",
             pt="Eu vou aniquilar toda a humanidade\n>:("
         ),
         Message(
-            en="I gonna kill you all\n>:(",
+            en="I will kill you all\n>:(",
             pt="Eu vou matar todos vocês\n>:("
         ),
         Message(

--- a/handler.py
+++ b/handler.py
@@ -27,4 +27,3 @@ class Handler:
         self.set_command_handler("cat", cat)
         self.set_command_handler("dog", dog)
         self.set_command_handler("image", image)
-  

--- a/main.py
+++ b/main.py
@@ -1,6 +1,10 @@
+import logging
 from os import environ
 from read_env import read_env
 from updater import get_updater
+
+logging.basicConfig(
+    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s')
 
 read_env()
 token = environ["TELEGRAM_BOT_TOKEN"]

--- a/message.py
+++ b/message.py
@@ -1,0 +1,26 @@
+class Message:
+    """
+    Message is used to build a message
+    with language options.
+    """
+
+    __idioms_and_texts = dict()
+
+    def __init__(self, **kwargs):
+        if "en" not in kwargs.keys():
+            raise Exception(
+                "The 'en' language code must be specified on a Message constructor")
+
+        for language_code, text in kwargs.items():
+            self.__idioms_and_texts[language_code] = text
+
+    def get_text(self, lang: str = "en"):
+        """
+        Returns the message text given
+        the language code. If the code
+        was not specified, it returns
+        the message with "en" code.
+        """
+        text = self.__idioms_and_texts[lang]
+
+        return text if text != None else self.__idioms_and_texts["en"]


### PR DESCRIPTION
Basicamente, foi adicionada uma nova classe chamada `Message()` onde pode ser definido na instanciação, várias opções de língua, e posteriormente, usar o texto passando a língua como parâmetro.

Exemplo:
```py
kill = Message(
    en="I gonna kill you all",
    pt="Eu vou matar todos vocês"
)

kill.get_text("en")
# => I gonna kill you all

kill.get_text("pt")
# => Eu vou matar todos vocês

# Francês não foi definido, portanto, o padrão de retorno é inglês
kill.get_text("fr")
# => I gonna kill you all
```

Esse parâmetro de linguagem, é definido a partir do código de idioma do usuário no telegram.